### PR TITLE
feat(mindweaver): add error details for etagMissmatch

### DIFF
--- a/packages/mindweaver/internal/mind/notes/errors_v3.go
+++ b/packages/mindweaver/internal/mind/notes/errors_v3.go
@@ -117,3 +117,26 @@ func newInvalidArgumentError(field, description string) error {
 
 	return err
 }
+
+// NOTE: I'll have to change it eventually as techically having the etag header precodindition
+// has to return 412 and not 409. When change don't forget the nvim client update
+func newETagMismatchError(ifMatchHeader, currentETag string) error {
+	err := connect.NewError(
+		connect.CodeFailedPrecondition,
+		fmt.Errorf("note has been modified: ETag mismatch"),
+	)
+
+	// Add ErrorInfo for machine-readable metadata (AIP-193)
+	errorInfo, _ := connect.NewErrorDetail(&errdetails.ErrorInfo{
+		Reason: "ETAG_MISMATCH",
+		Domain: errorDomain,
+		Metadata: map[string]string{
+			"provided_etag": ifMatchHeader,
+			"current_etag":  currentETag,
+			"header":        "If-Match",
+		},
+	})
+	err.AddDetail(errorInfo)
+
+	return err
+}

--- a/packages/mindweaver/internal/mind/notes/notes_handlers_v3.go
+++ b/packages/mindweaver/internal/mind/notes/notes_handlers_v3.go
@@ -7,13 +7,13 @@ import (
 	"strconv"
 
 	"connectrpc.com/connect"
-	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/links"
-	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/meta"
-	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/gen/store"
-	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/tags"
-	"github.com/nkapatos/mindweaver/packages/mindweaver/shared/dberrors"
 	mindv3 "github.com/nkapatos/mindweaver/packages/mindweaver/gen/proto/mind/v3"
 	"github.com/nkapatos/mindweaver/packages/mindweaver/gen/proto/mind/v3/mindv3connect"
+	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/gen/store"
+	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/links"
+	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/meta"
+	"github.com/nkapatos/mindweaver/packages/mindweaver/internal/mind/tags"
+	"github.com/nkapatos/mindweaver/packages/mindweaver/shared/dberrors"
 	"github.com/nkapatos/mindweaver/packages/mindweaver/shared/pagination"
 	"github.com/nkapatos/mindweaver/packages/mindweaver/shared/utils"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -95,7 +95,7 @@ func (h *NotesHandlerV3) ReplaceNote(
 	if req.Header().Get("If-Match") != "" {
 		currentETag := utils.ComputeHashedETag(current.Version)
 		if req.Header().Get("If-Match") != currentETag {
-			return nil, connect.NewError(connect.CodeAborted, ErrStaleNote)
+			return nil, newETagMismatchError(req.Header().Get("If-Match"), currentETag)
 		}
 	}
 


### PR DESCRIPTION
Connect error response codes do not cover 412 and return only 409 which is not correct if the precondition fails in the header etag. 

This is a wrapping error details to respond with the additional information for the consumers while retaining the 409 response to match gRPC and API calls