### PR TITLE
feat(neoweaver): add dedicated repository sync workflow

### DIFF
--- a/.github/workflows/release-neoweaver.yml
+++ b/.github/workflows/release-neoweaver.yml
@@ -19,20 +19,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Prepare package
+      - name: Sync to dedicated repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEOWEAVER_SYNC_TOKEN }}
         run: |
+          # Extract version from tag (neoweaver/v0.6.0 -> v0.6.0)
           TAG_NAME="${GITHUB_REF_NAME#neoweaver/}"
-          VERSION="${TAG_NAME#v}"
-          mkdir -p dist
-          tar -czf "dist/neoweaver-${TAG_NAME}.tar.gz" -C clients neoweaver
-          (cd clients && zip -r "../dist/neoweaver-${TAG_NAME}.zip" neoweaver >/dev/null)
-          echo "asset_tag=${TAG_NAME}" >> "$GITHUB_ENV"
-          echo "asset_version=${VERSION}" >> "$GITHUB_ENV"
-
-      - name: Upload release assets
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          tag: ${{ github.ref_name }}
-          artifacts: dist/neoweaver-${{ env.asset_tag }}.tar.gz,dist/neoweaver-${{ env.asset_tag }}.zip
-          artifactContentType: application/gzip
+          
+          # Configure git
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Clone dedicated repo
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/nkapatos/neoweaver.nvim.git" sync-repo
+          cd sync-repo
+          
+          # Remove all existing files (clean slate)
+          git rm -rf . 2>/dev/null || true
+          git clean -fdx
+          
+          # Copy runtime files from monorepo
+          cp -r ../clients/neoweaver/lua .
+          cp -r ../clients/neoweaver/plugin .
+          cp -r ../clients/neoweaver/doc .
+          cp ../clients/neoweaver/README.md .
+          cp ../clients/neoweaver/CHANGELOG.md .
+          cp ../clients/neoweaver/LICENSE .
+          
+          # Add sync notice to README (prepend)
+          cat > README.tmp.md << 'NOTICE'
+          > **⚠️ READ-ONLY MIRROR:** This repository is automatically synchronized from the [MindWeaver monorepo](https://github.com/nkapatos/mindweaver/tree/main/clients/neoweaver).
+          >
+          > **For issues, PRs, and development:** Please visit the [main repository](https://github.com/nkapatos/mindweaver).
+          
+          ---
+          
+          NOTICE
+          cat README.md >> README.tmp.md
+          mv README.tmp.md README.md
+          
+          # Commit and push
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "sync: release ${TAG_NAME}"
+          fi
+          
+          # Create and push tag
+          git tag "${TAG_NAME}" || true
+          git push origin main --tags

--- a/clients/neoweaver/LICENSE
+++ b/clients/neoweaver/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nikolaos Kapatos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clients/neoweaver/README.md
+++ b/clients/neoweaver/README.md
@@ -15,7 +15,7 @@ Install with your preferred package manager. Example using **lazy.nvim**:
 ```lua
 return {
   {
-    dir = "path/to/neoweaver",
+    "nkapatos/neoweaver.nvim",
     cmd = {
       "NeoweaverNotesList",
       "NeoweaverNotesOpen",

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -203,6 +203,18 @@ The mindweaver server is a single binary containing both Mind and Brain services
 - Can release without server changes
 - Document compatibility: "requires mindweaver >= X.Y.Z"
 
+### Dedicated Client Repository (neoweaver.nvim)
+
+The Neovim client is automatically synced to a dedicated repository for plugin manager compatibility:
+
+- **Development:** All work happens in `clients/neoweaver/` in the monorepo
+- **Distribution:** Auto-synced to `github.com/nkapatos/neoweaver.nvim` on release
+- **Tags:** Monorepo `neoweaver/v0.6.0` → `v0.6.0` in dedicated repo
+- **Files synced:** lua/, plugin/, doc/, README.md, CHANGELOG.md, LICENSE
+- **License:** MIT (client) vs AGPL-3.0 (server)
+- **User installation:** `{ "nkapatos/neoweaver.nvim" }`
+- **Issue tracking:** File issues in monorepo, not mirror
+
 **Shared Libraries (`packages/pkg`):**
 - Currently not independently versioned
 - Used internally by mindweaver


### PR DESCRIPTION
- Create dedicated neoweaver.nvim repo for plugin manager compatibility
- Add MIT license for client (separate from server AGPL-3.0)
- Update release workflow to sync files instead of creating packages
- Sync lua/, plugin/, doc/, README, CHANGELOG, LICENSE to mirror repo
- Strip neoweaver/ prefix from tags (neoweaver/v0.6.0 -> v0.6.0)
- Update installation docs to use nkapatos/neoweaver.nvim
- Document sync strategy in WORKFLOW.md