### PR TITLE
ci: component-scoped filters, Go cache; neoweaver release sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mindweaver: ${{ steps.filter.outputs.mindweaver }}
+      neoweaver: ${{ steps.filter.outputs.neoweaver }}
       root-config: ${{ steps.filter.outputs.root-config }}
     steps:
       - name: Checkout code
@@ -70,9 +71,12 @@ jobs:
             mindweaver:
               - 'packages/mindweaver/**'
               - '!packages/mindweaver/tests/**'
+            neoweaver:
+              - 'clients/neoweaver/**'
             root-config:
               - 'packages/Taskfile.yaml'
               - '.mise.toml'
+
 
   # ---------------------------------------------------------------------------
   # Test mindweaver package
@@ -92,6 +96,7 @@ jobs:
         with:
           go-version: '1.25.5'
           cache: true
+          cache-dependency-path: packages/mindweaver/go.sum
 
       - name: Setup Task
         uses: go-task/setup-task@v1
@@ -111,6 +116,7 @@ jobs:
       - name: Generate code
         run: task mw:proto:generate && task mind:db:store:generate
         working-directory: packages/mindweaver
+
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
@@ -144,6 +150,7 @@ jobs:
         with:
           go-version: '1.25.5'
           cache: true
+          cache-dependency-path: packages/mindweaver/go.sum
 
       - name: Setup Task
         uses: go-task/setup-task@v1
@@ -163,6 +170,7 @@ jobs:
       - name: Build binary
         run: task mw:build
         working-directory: packages/mindweaver
+
 
       - name: Verify binary
         run: ./bin/mindweaver --version || true

--- a/.github/workflows/release-neoweaver.yml
+++ b/.github/workflows/release-neoweaver.yml
@@ -46,8 +46,9 @@ jobs:
           cp ../clients/neoweaver/CHANGELOG.md .
           cp ../clients/neoweaver/LICENSE .
           
-          # Add sync notice to README (prepend)
-          cat > README.tmp.md << 'NOTICE'
+          # Add sync notice to README once (prepend)
+          if ! grep -q "READ-ONLY MIRROR" README.md; then
+            cat > README.tmp.md << 'NOTICE'
           > **⚠️ READ-ONLY MIRROR:** This repository is automatically synchronized from the [MindWeaver monorepo](https://github.com/nkapatos/mindweaver/tree/main/clients/neoweaver).
           >
           > **For issues, PRs, and development:** Please visit the [main repository](https://github.com/nkapatos/mindweaver).
@@ -55,8 +56,9 @@ jobs:
           ---
           
           NOTICE
-          cat README.md >> README.tmp.md
-          mv README.tmp.md README.md
+            cat README.md >> README.tmp.md
+            mv README.tmp.md README.md
+          fi
           
           # Commit and push
           git add -A
@@ -68,4 +70,4 @@ jobs:
           
           # Create and push tag
           git tag "${TAG_NAME}" || true
-          git push origin main --tags
+          git push origin HEAD:main --tags

--- a/packages/mindweaver/tasks/tasks.ci.yml
+++ b/packages/mindweaver/tasks/tasks.ci.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+tasks:
+  prepare:
+    desc: Prepare generated assets for CI
+    cmds:
+      - task: :mw:proto:generate
+      - task: :mind:db:store:generate
+
+  test:
+    desc: Run mindweaver tests with coverage
+    deps:
+      - prepare
+    cmds:
+      - go test -v -race -coverprofile=coverage.out ./...
+
+  build:
+    desc: Build mindweaver binary for CI
+    deps:
+      - prepare
+    cmds:
+      - task: :mw:build


### PR DESCRIPTION
## Summary
- CI filters now include neoweaver; mindweaver jobs gated to component changes.
- Go caching keyed to packages/mindweaver/go.sum added to test/build jobs.
- Neoweaver release sync hardened: one-time README banner, push via HEAD:main, tag carry-over.
- Added Task-based CI targets in packages/mindweaver/tasks/tasks.ci.yml for local/CI parity.

## Notes
- Neoweaver CI job (fmt/lint) can be added next; filters already present.
