### PR TITLE
fix(ci): use GitHub API for path detection on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,20 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       mindweaver: ${{ steps.filter.outputs.mindweaver }}
       neoweaver: ${{ steps.filter.outputs.neoweaver }}
       root-config: ${{ steps.filter.outputs.root-config }}
     steps:
+      # For pull_request events, paths-filter uses GitHub API (no checkout needed)
+      # For push events, it needs git history to compare commits
       - name: Checkout code
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 20
 
       - name: Check paths
         uses: dorny/paths-filter@v3

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 # Local development and reference directories (matches at any depth)
 project_local_files/
 
+# Local GitHub Actions testing (act)
+.github/act/
+
 # Go workspace files (developer-specific)
 go.work
 go.work.sum


### PR DESCRIPTION
## Summary
- Fix CI running all jobs even when only unrelated files changed (like .gitignore)
- For pull_request events: skip checkout, let dorny/paths-filter use GitHub REST API
- For push events: checkout with fetch-depth: 20 for git history comparison