### PR TITLE
ci(neoweaver): ensure target-side docs workflow runs on sync PR branches

### DIFF
--- a/.github/neoweaver-sync.yml
+++ b/.github/neoweaver-sync.yml
@@ -1,0 +1,4 @@
+nkapatos/neoweaver.nvim:
+  source: clients/neoweaver/   # Trailing / to sync the entire directory contents
+  dest: ./                     # Sync to the root of the target repo
+  deleteOrphaned: true         # Optional: delete files in target root that no longer exist in source

--- a/.github/workflows/release-neoweaver.yml
+++ b/.github/workflows/release-neoweaver.yml
@@ -1,0 +1,90 @@
+name: Sync Neoweaver to Mirror Repo
+
+on:
+  push:
+    tags:
+      - 'neoweaver/v*'   
+
+permissions:
+  contents: read   
+
+jobs:
+  sync-neoweaver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Sync to mirror repo
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.NEOWEAVER_SYNC_TOKEN }}
+          CONFIG_PATH: .github/neoweaver-sync.yml
+          COMMIT_PREFIX: '[Sync] Neoweaver '
+          PR_LABELS: automated-sync,neoweaver
+          BRANCH_PREFIX: sync
+          PR_BODY: |
+            Automated sync of Neoweaver plugin files from monorepo release tag ${{ github.ref_name }}.
+
+            This keeps the standalone repo up-to-date for direct use by Neovim plugin managers.
+          OVERWRITE_EXISTING_PR: true 
+
+# name: Release Neoweaver
+# on:
+#   push:
+#     tags:
+#       - 'neoweaver/v*'
+#
+# permissions:
+#   contents: write  
+#
+# jobs:
+#   release:
+#     name: Publish Neoweaver assets
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout source
+#         uses: actions/checkout@v4
+#
+#       - name: Checkout target repo
+#         uses: actions/checkout@v4
+#         with:
+#           repository: nkapatos/neoweaver.nvim
+#           path: target
+#           token: ${{ secrets.NEOWEAVER_SYNC_TOKEN }}
+#           fetch-depth: 0  
+#
+#       - name: Copy files
+#         run: |
+#           cp -r ./clients/neoweaver/* target/
+#
+#       - name: Create/Update sync branch and PR
+#         run: |
+#           cd target
+#           git config user.name "github-actions[bot]"
+#           git config user.email "github-actions[bot]@users.noreply.github.com"
+#
+#           BRANCH="sync/from-monorepo"
+#           git checkout -B $BRANCH
+#
+#           git add .
+#           if git diff --staged --quiet; then
+#             echo "No changes to commit"
+#             exit 0
+#           fi
+#
+#           git commit -m "Sync Neoweaver files from monorepo (tag ${{ github.ref_name }})"
+#
+#           git push origin $BRANCH --force
+#
+#           # Create PR if none exists; fails gracefully if already open
+#           if gh pr view $BRANCH --json state | grep -q '"state":"OPEN"'; then
+#             echo "PR already open, skipping creation"
+#           else
+#           gh pr create --title "Sync Neoweaver from monorepo" \
+#                        --body "Automated sync for tag ${{ github.ref_name }}" \
+#                        --base main \
+#                        --head $BRANCH 
+#           fi
+#         env:
+#           GH_TOKEN: ${{ secrets.NEOWEAVER_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary
- Set repo-file-sync-action `BRANCH_PREFIX: sync` so PR branches in target repo start with `sync/` and trigger `generate-docs.yml`\n- Keep existing sync config (clients/neoweaver/ -> repo root, deleteOrphaned: true)\n\n## Context
Target repo workflow filters PRs by `github.head_ref` prefix `sync/`. This change aligns branch naming without altering the mirroring approach.\n