### PR TITLE
ci: add workflow_dispatch to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds manual trigger capability to the release-please workflow, allowing re-runs via Actions UI after merging one release PR to update the manifest for remaining PRs