### PR TITLE
feat: add Docker Hub publishing to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,15 @@ jobs:
       - name: Generate code (proto + sqlc)
         run: task ci:prepare
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -154,3 +154,39 @@ release:
     ---
     
     **Full Changelog**: https://github.com/nkapatos/mindweaver/compare/{{.PreviousTag}}...{{.Tag}}
+
+# Docker images
+dockers:
+  - id: mindweaver-amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "codefupandas/mindweaver:{{ .Version }}-amd64"
+      - "codefupandas/mindweaver:latest-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+
+  - id: mindweaver-arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "codefupandas/mindweaver:{{ .Version }}-arm64"
+      - "codefupandas/mindweaver:latest-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+# Multi-arch manifests
+docker_manifests:
+  - name_template: "codefupandas/mindweaver:{{ .Version }}"
+    image_templates:
+      - "codefupandas/mindweaver:{{ .Version }}-amd64"
+      - "codefupandas/mindweaver:{{ .Version }}-arm64"
+
+  - name_template: "codefupandas/mindweaver:latest"
+    image_templates:
+      - "codefupandas/mindweaver:latest-amd64"
+      - "codefupandas/mindweaver:latest-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates tzdata
+COPY mindweaver /usr/local/bin/
+EXPOSE 9421
+ENTRYPOINT ["mindweaver"]
+CMD ["--mode=combined"]


### PR DESCRIPTION
## Summary

- Add minimal Dockerfile for GoReleaser to use
- Configure GoReleaser to build multi-arch Docker images (amd64/arm64)
- Add Docker Hub login to release workflow

## Docker Images

After release, images will be available at:
- `codefupandas/mindweaver:<version>`
- `codefupandas/mindweaver:latest`

Both tags are multi-arch manifests supporting `linux/amd64` and `linux/arm64`.

## Required Secrets

Add these to repo settings before merging:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (Read & Write scope)

## Related

- #73 - Support Docker-friendly configuration (follow-up for env var documentation)