### PR TITLE
fix: update goreleaser config to remove deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,8 @@ builds:
 # Archives configuration
 archives:
   - id: mindweaver
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -66,7 +67,7 @@ checksum:
 
 # Snapshot configuration (for development builds)
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 # Changelog configuration
 changelog:
@@ -155,38 +156,10 @@ release:
     
     **Full Changelog**: https://github.com/nkapatos/mindweaver/compare/{{.PreviousTag}}...{{.Tag}}
 
-# Docker images
-dockers:
-  - id: mindweaver-amd64
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "codefupandas/mindweaver:{{ .Version }}-amd64"
-      - "codefupandas/mindweaver:latest-amd64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-
-  - id: mindweaver-arm64
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "codefupandas/mindweaver:{{ .Version }}-arm64"
-      - "codefupandas/mindweaver:latest-arm64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-
-# Multi-arch manifests
-docker_manifests:
-  - name_template: "codefupandas/mindweaver:{{ .Version }}"
-    image_templates:
-      - "codefupandas/mindweaver:{{ .Version }}-amd64"
-      - "codefupandas/mindweaver:{{ .Version }}-arm64"
-
-  - name_template: "codefupandas/mindweaver:latest"
-    image_templates:
-      - "codefupandas/mindweaver:latest-amd64"
-      - "codefupandas/mindweaver:latest-arm64"
+# Docker images (v2 format - builds multi-arch manifest in single step)
+dockers_v2:
+  - images:
+      - "codefupandas/mindweaver"
+    tags:
+      - "{{ .Version }}"
+      - "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates tzdata
-COPY mindweaver /usr/local/bin/
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/mindweaver /usr/local/bin/
 EXPOSE 9421
 ENTRYPOINT ["mindweaver"]
 CMD ["--mode=combined"]


### PR DESCRIPTION
## Summary

Updates GoReleaser configuration to fix deprecation warnings:

- `snapshot.name_template` → `snapshot.version_template`
- `archives.format` → `archives.formats` (list format)
- `dockers` + `docker_manifests` → `dockers_v2` (new simpler format)
- Update Dockerfile for `TARGETPLATFORM` support required by `dockers_v2`

## Changes

The new `dockers_v2` format is much simpler - GoReleaser handles multi-arch manifests automatically with a single `docker buildx build` command instead of building separate images and then creating manifests.

## Related

- #74 - feat: add Docker Hub publishing to release workflow