### PR TITLE
feat(mind): add UpdateNote RPC for partial updates (PATCH)

### DIFF
--- a/internal/mind/notes/notes_converters.go
+++ b/internal/mind/notes/notes_converters.go
@@ -91,6 +91,51 @@ func ProtoReplaceNoteToStore(req *mindv3.ReplaceNoteRequest, current store.Note)
 	}
 }
 
+// ProtoUpdateNoteToStore merges UpdateNoteRequest fields with current note.
+// Only fields present in the request (non-nil) are updated; others keep current values.
+// This implements PATCH semantics per AIP-134.
+func ProtoUpdateNoteToStore(req *mindv3.UpdateNoteRequest, current store.Note) store.UpdateNoteByIDParams {
+	params := store.UpdateNoteByIDParams{
+		ID:           req.Id,
+		Uuid:         current.Uuid,
+		Version:      current.Version,
+		Title:        current.Title,
+		Body:         current.Body,
+		Description:  current.Description,
+		Frontmatter:  current.Frontmatter,
+		NoteTypeID:   current.NoteTypeID,
+		IsTemplate:   current.IsTemplate,
+		CollectionID: current.CollectionID,
+	}
+
+	// Merge each field: use request value if set, otherwise keep current
+	if req.Title != nil {
+		params.Title = *req.Title
+	}
+
+	if req.Body != nil {
+		params.Body = utils.NullStringFrom(*req.Body, true)
+	}
+
+	if req.Description != nil {
+		params.Description = utils.NullStringFrom(*req.Description, true)
+	}
+
+	if req.NoteTypeId != nil {
+		params.NoteTypeID = utils.NullInt64(*req.NoteTypeId)
+	}
+
+	if req.CollectionId != nil {
+		params.CollectionID = *req.CollectionId
+	}
+
+	if req.IsTemplate != nil {
+		params.IsTemplate = utils.NullBool(*req.IsTemplate)
+	}
+
+	return params
+}
+
 // ProtoNewNoteToParams extracts collection_id and template_id from NewNoteRequest.
 // Returns defaulted values: collection_id defaults to 1, template_id defaults to 1.
 func ProtoNewNoteToParams(req *mindv3.NewNoteRequest) (collectionID, templateID int64) {

--- a/proto/mind/v3/notes.proto
+++ b/proto/mind/v3/notes.proto
@@ -144,6 +144,35 @@ message ReplaceNoteRequest {
   map<string, string> metadata = 8;
 }
 
+// Request message for UpdateNote (AIP-134 PATCH - partial update)
+// Only fields present in the request are modified; others remain unchanged
+// Requires If-Match header with ETag for optimistic locking
+message UpdateNoteRequest {
+  // Note ID (required)
+  int64 id = 1 [(buf.validate.field).int64.gt = 0];
+  
+  // Optional: New title (max 255 chars)
+  optional string title = 2 [(buf.validate.field).string = {
+    min_len: 1,
+    max_len: 255
+  }];
+  
+  // Optional: New body content
+  optional string body = 3;
+  
+  // Optional: New description (max 600 chars)
+  optional string description = 4 [(buf.validate.field).string.max_len = 600];
+  
+  // Optional: New note type ID
+  optional int64 note_type_id = 5 [(buf.validate.field).int64.gt = 0];
+  
+  // Optional: New collection ID
+  optional int64 collection_id = 6 [(buf.validate.field).int64.gt = 0];
+  
+  // Optional: New template flag
+  optional bool is_template = 7;
+}
+
 // Request message for DeleteNote (AIP-135)
 message DeleteNoteRequest {
   // Note ID (required)
@@ -263,6 +292,16 @@ service NotesService {
   rpc ReplaceNote(ReplaceNoteRequest) returns (Note) {
     option (google.api.http) = {
       put: "/v3/notes/{id}"
+      body: "*"
+    };
+  }
+  
+  // Update a note (AIP-134) - PATCH operation for partial update
+  // Only fields present in the request are modified; others remain unchanged
+  // Requires If-Match header with ETag for optimistic locking
+  rpc UpdateNote(UpdateNoteRequest) returns (Note) {
+    option (google.api.http) = {
+      patch: "/v3/notes/{id}"
       body: "*"
     };
   }

--- a/tests/api/mind-v3/notes/2-get-note.bru
+++ b/tests/api/mind-v3/notes/2-get-note.bru
@@ -20,6 +20,13 @@ body:json {
   }
 }
 
+script:post-response {
+  if (res.status === 200 && res.body.etag) {
+    bru.setEnvVar("noteEtag", res.body.etag);
+    console.log("Captured ETag:", res.body.etag);
+  }
+}
+
 tests {
   test("Status is 200", function() {
     expect(res.status).to.equal(200);

--- a/tests/api/mind-v3/notes/5-update-note.bru
+++ b/tests/api/mind-v3/notes/5-update-note.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Update Note (PATCH)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/mind.v3.NotesService/UpdateNote
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  If-Match: {{noteEtag}}
+}
+
+body:json {
+  {
+    "id": {{noteId}},
+    "title": "Partially Updated Title"
+  }
+}
+
+script:pre-request {
+  // First get the current note to obtain its ETag
+  const noteId = bru.getEnvVar("noteId");
+  if (!noteId) {
+    console.log("Warning: noteId not set, test may fail");
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body.etag) {
+    bru.setEnvVar("noteEtag", res.body.etag);
+    console.log("Updated ETag:", res.body.etag);
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  
+  test("Response has correct note ID", function() {
+    expect(res.body.id).to.equal(bru.getEnvVar("noteId").toString());
+  });
+  
+  test("Title was updated", function() {
+    expect(res.body.title).to.equal("Partially Updated Title");
+  });
+  
+  test("Body was preserved (not cleared)", function() {
+    expect(res.body).to.have.property("body");
+    expect(res.body.body).to.be.a("string");
+  });
+  
+  test("ETag was updated", function() {
+    expect(res.body.etag).to.be.a("string");
+    expect(res.body.etag).to.match(/^W\//);
+  });
+}

--- a/tests/api/mind-v3/notes/6-update-note-missing-etag.bru
+++ b/tests/api/mind-v3/notes/6-update-note-missing-etag.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Update Note - Missing ETag
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/mind.v3.NotesService/UpdateNote
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "id": {{noteId}},
+    "title": "Should Fail Without ETag"
+  }
+}
+
+tests {
+  test("Status is 400 (FAILED_PRECONDITION)", function() {
+    expect(res.status).to.equal(400);
+  });
+  
+  test("Error code indicates ETag required", function() {
+    expect(res.body.code).to.equal("failed_precondition");
+  });
+}


### PR DESCRIPTION
## Summary

- Add AIP-134 compliant PATCH endpoint for notes allowing partial updates
- Only fields present in the request are modified; others remain unchanged
- Require `If-Match` header with ETag for optimistic concurrency control

## Changes

- `proto/mind/v3/notes.proto`: Add `UpdateNoteRequest` message and `UpdateNote` RPC
- `internal/mind/notes/notes_converters.go`: Add `ProtoUpdateNoteToStore` converter with PATCH merge semantics
- `internal/mind/notes/notes_handlers.go`: Add `UpdateNote` handler with required ETag validation
- `tests/api/mind-v3/notes/`: Add Bruno API tests for update and missing ETag error case

## API

```
PATCH /v3/notes/{id}
```

Request body (all fields optional except id):
```json
{
  "id": 123,
  "title": "New Title",
  "body": "New body content",
  "description": "New description",
  "note_type_id": 2,
  "collection_id": 1,
  "is_template": false
}
```

Requires `If-Match` header with current ETag for optimistic locking.