### PR TITLE
feat(mind): version body changes only, add relocated event

### DIFF
--- a/internal/mind/notes/notes_converters.go
+++ b/internal/mind/notes/notes_converters.go
@@ -136,6 +136,43 @@ func ProtoUpdateNoteToStore(req *mindv3.UpdateNoteRequest, current store.Note) s
 	return params
 }
 
+// ProtoUpdateNoteMetadataToStore merges UpdateNoteRequest metadata fields with current note.
+// Only metadata fields (title, description, note_type_id, collection_id, is_template) are updated.
+// Body is not included - this is for metadata-only updates that skip version checks.
+func ProtoUpdateNoteMetadataToStore(req *mindv3.UpdateNoteRequest, current store.Note) store.UpdateNoteMetadataByIDParams {
+	params := store.UpdateNoteMetadataByIDParams{
+		ID:           req.Id,
+		Title:        current.Title,
+		Description:  current.Description,
+		NoteTypeID:   current.NoteTypeID,
+		IsTemplate:   current.IsTemplate,
+		CollectionID: current.CollectionID,
+	}
+
+	// Merge each field: use request value if set, otherwise keep current
+	if req.Title != nil {
+		params.Title = *req.Title
+	}
+
+	if req.Description != nil {
+		params.Description = utils.NullStringFrom(*req.Description, true)
+	}
+
+	if req.NoteTypeId != nil {
+		params.NoteTypeID = utils.NullInt64(*req.NoteTypeId)
+	}
+
+	if req.CollectionId != nil {
+		params.CollectionID = *req.CollectionId
+	}
+
+	if req.IsTemplate != nil {
+		params.IsTemplate = utils.NullBool(*req.IsTemplate)
+	}
+
+	return params
+}
+
 // ProtoNewNoteToParams extracts collection_id and template_id from NewNoteRequest.
 // Returns defaulted values: collection_id defaults to 1, template_id defaults to 1.
 func ProtoNewNoteToParams(req *mindv3.NewNoteRequest) (collectionID, templateID int64) {

--- a/migrations/mind/20251208095844_init_mind_schema.sql
+++ b/migrations/mind/20251208095844_init_mind_schema.sql
@@ -50,7 +50,7 @@ UNIQUE (parent_id, name)
 -- ========================================
 CREATE TABLE notes (
 id INTEGER PRIMARY KEY AUTOINCREMENT,
-uuid TEXT NOT NULL UNIQUE,  -- UUIDv7 for sync and time-ordering
+uuid TEXT NOT NULL UNIQUE,  -- UUID v4 for unique identification
 title TEXT NOT NULL,
 -- Nullable: allows title-only notes (quick capture)
 body TEXT,

--- a/proto/mind/v3/events.proto
+++ b/proto/mind/v3/events.proto
@@ -31,6 +31,7 @@ enum EventType {
   EVENT_TYPE_CREATED = 1;
   EVENT_TYPE_UPDATED = 2;
   EVENT_TYPE_DELETED = 3;
+  EVENT_TYPE_RELOCATED = 4;   // Note title or collection changed (affects path)
   // System event types
   EVENT_TYPE_CONNECTED = 10;   // Client successfully connected to stream
   EVENT_TYPE_SHUTDOWN = 11;    // Server is shutting down gracefully
@@ -63,4 +64,21 @@ message Event {
   // Session ID assigned to a client on SSE connect (only set in connected events).
   // Clients should store this and include it as X-Session-Id header in subsequent requests.
   string session_id = 7;
+
+  // Relocated event payload (only set for EVENT_TYPE_RELOCATED)
+  optional RelocatedPayload relocated = 8;
+}
+
+// RelocatedPayload contains details about a note relocation event.
+// Sent when a note's title or collection_id changes, affecting its path.
+// Only changed fields are populated.
+message RelocatedPayload {
+  // Previous title (only set if title changed)
+  optional string old_title = 1;
+  // New title (only set if title changed)
+  optional string new_title = 2;
+  // Previous collection ID (only set if collection changed)
+  optional int64 old_collection_id = 3;
+  // New collection ID (only set if collection changed)
+  optional int64 new_collection_id = 4;
 }


### PR DESCRIPTION
## Summary

- Version increments only when note body changes, not metadata (title, description, collection_id)
- Metadata-only PATCH updates no longer require ETag header
- New `EVENT_TYPE_RELOCATED` SSE event notifies clients when note path changes (title or collection)
- Stale note detection via `sql.Result.RowsAffected()` for optimistic locking

## Changes

### API Behavior
- `PATCH /notes/{id}` with `body` field: requires `If-Match` header, increments version
- `PATCH /notes/{id}` without `body` field: no ETag required, version unchanged

### SSE Events
- New `relocated` event type with payload: `old_title`, `new_title`, `old_collection_id`, `new_collection_id`
- Only changed fields are populated in the payload