### PR TITLE
feat(mind): add ListNotesForTag and FindTags V3 endpoints

### DIFF
--- a/internal/mind/tags/tags_converters.go
+++ b/internal/mind/tags/tags_converters.go
@@ -5,6 +5,7 @@ import (
 
 	mindv3 "github.com/nkapatos/mindweaver/gen/proto/mind/v3"
 	"github.com/nkapatos/mindweaver/internal/mind/gen/store"
+	"github.com/nkapatos/mindweaver/shared/utils"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -29,6 +30,43 @@ func StoreTagsToProto(tags []store.Tag) []*mindv3.Tag {
 	result := make([]*mindv3.Tag, len(tags))
 	for i, tag := range tags {
 		result[i] = StoreTagToProto(tag)
+	}
+	return result
+}
+
+// StoreNoteToProto converts a store.Note to proto Note for ListNotesForTag.
+// Note: This is a local copy to avoid import cycle with notes package.
+func StoreNoteToProto(note store.Note) *mindv3.Note {
+	var body *string
+	if note.Body.Valid {
+		fullBody := note.Body.String
+		body = &fullBody
+	}
+
+	name := fmt.Sprintf("notes/%d", note.ID)
+	etag := utils.ComputeHashedETag(note.Version)
+
+	return &mindv3.Note{
+		Id:           note.ID,
+		Uuid:         note.Uuid.String(),
+		Name:         name,
+		Title:        note.Title,
+		Body:         body,
+		Description:  utils.FromNullString(note.Description),
+		NoteTypeId:   utils.FromNullInt64(note.NoteTypeID),
+		CollectionId: note.CollectionID,
+		IsTemplate:   utils.FromNullBool(note.IsTemplate),
+		Etag:         etag,
+		CreateTime:   timestamppb.New(note.CreatedAt.Time),
+		UpdateTime:   timestamppb.New(note.UpdatedAt.Time),
+	}
+}
+
+// StoreNotesToProto converts a slice of store.Note to proto Note messages.
+func StoreNotesToProto(notes []store.Note) []*mindv3.Note {
+	result := make([]*mindv3.Note, len(notes))
+	for i, note := range notes {
+		result[i] = StoreNoteToProto(note)
 	}
 	return result
 }

--- a/internal/mind/tags/tags_handlers.go
+++ b/internal/mind/tags/tags_handlers.go
@@ -87,9 +87,12 @@ func (h *TagsHandler) ListNotesForTag(
 
 	// Get total count (only on first page)
 	var totalCount int64
+	var countErr error
 	if pageReq.IsFirstPage() {
-		totalCount, _ = h.service.CountNotesForTag(ctx, req.Msg.TagId)
+		totalCount, countErr = h.service.CountNotesForTag(ctx, req.Msg.TagId)
 	}
+	// Count errors are logged in service but don't fail the request
+	_ = countErr
 
 	// Build pagination response
 	pageResp := pageReq.BuildResponse(len(notes), totalCount)
@@ -124,9 +127,12 @@ func (h *TagsHandler) FindTags(
 
 	// Get total count (only on first page)
 	var totalCount int64
+	var countErr error
 	if pageReq.IsFirstPage() {
-		totalCount, _ = h.service.CountFindTags(ctx, req.Msg.Name)
+		totalCount, countErr = h.service.CountFindTags(ctx, req.Msg.Name)
 	}
+	// Count errors are logged in service but don't fail the request
+	_ = countErr
 
 	// Build pagination response
 	pageResp := pageReq.BuildResponse(len(tags), totalCount)

--- a/internal/mind/tags/tags_services.go
+++ b/internal/mind/tags/tags_services.go
@@ -186,3 +186,47 @@ func (s *TagsService) ListNotesForTag(ctx context.Context, tagID int64) ([]store
 	}
 	return notes, err
 }
+
+// ListNotesForTagPaginated returns notes for a tag with pagination.
+func (s *TagsService) ListNotesForTagPaginated(ctx context.Context, tagID int64, limit, offset int32) ([]store.Note, error) {
+	notes, err := s.store.ListNotesForTagPaginated(ctx, store.ListNotesForTagPaginatedParams{
+		TagID:  tagID,
+		Limit:  int64(limit),
+		Offset: int64(offset),
+	})
+	if err != nil {
+		s.logger.Error("failed to list notes for tag paginated", "tag_id", tagID, "err", err, "request_id", middleware.GetRequestID(ctx))
+	}
+	return notes, err
+}
+
+// CountNotesForTag returns the total number of notes for a tag.
+func (s *TagsService) CountNotesForTag(ctx context.Context, tagID int64) (int64, error) {
+	count, err := s.store.CountNotesForTag(ctx, tagID)
+	if err != nil {
+		s.logger.Error("failed to count notes for tag", "tag_id", tagID, "err", err, "request_id", middleware.GetRequestID(ctx))
+	}
+	return count, err
+}
+
+// FindTagsPaginated returns tags matching a name pattern with pagination.
+func (s *TagsService) FindTagsPaginated(ctx context.Context, pattern string, limit, offset int32) ([]store.Tag, error) {
+	tags, err := s.store.FindTagsPaginated(ctx, store.FindTagsPaginatedParams{
+		Pattern: pattern,
+		Limit:   int64(limit),
+		Offset:  int64(offset),
+	})
+	if err != nil {
+		s.logger.Error("failed to find tags paginated", "pattern", pattern, "err", err, "request_id", middleware.GetRequestID(ctx))
+	}
+	return tags, err
+}
+
+// CountFindTags returns the total number of tags matching a name pattern.
+func (s *TagsService) CountFindTags(ctx context.Context, pattern string) (int64, error) {
+	count, err := s.store.CountFindTags(ctx, pattern)
+	if err != nil {
+		s.logger.Error("failed to count find tags", "pattern", pattern, "err", err, "request_id", middleware.GetRequestID(ctx))
+	}
+	return count, err
+}

--- a/proto/mind/v3/tags.proto
+++ b/proto/mind/v3/tags.proto
@@ -9,6 +9,7 @@ import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 import "buf/validate/validate.proto";
+import "v3/notes.proto";
 
 option go_package = "github.com/nkapatos/mindweaver/internal/mind/gen/v3;mindv3";
 
@@ -19,6 +20,21 @@ service TagsService {
   rpc ListTags(ListTagsRequest) returns (ListTagsResponse) {
     option (google.api.http) = {
       get: "/api/mind/v3/tags"
+    };
+  }
+
+  // Lists notes for a specific tag (AIP-132 sub-resource)
+  rpc ListNotesForTag(ListNotesForTagRequest) returns (ListNotesForTagResponse) {
+    option (google.api.http) = {
+      get: "/api/mind/v3/tags/{tag_id}/notes"
+    };
+  }
+
+  // Find tags by name pattern (AIP-136 custom method)
+  rpc FindTags(FindTagsRequest) returns (FindTagsResponse) {
+    option (google.api.http) = {
+      post: "/api/mind/v3/tags:find"
+      body: "*"
     };
   }
 }
@@ -72,4 +88,60 @@ message ListTagsResponse {
   optional int32 total_size = 3;
 }
 
+// Request to list notes for a specific tag (AIP-132 sub-resource)
+message ListNotesForTagRequest {
+  // Tag ID (required)
+  int64 tag_id = 1 [(buf.validate.field).int64.gt = 0];
 
+  // Maximum number of notes to return (default: 50, max: 100)
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 0,
+    lte: 100
+  }];
+
+  // Page token from previous response
+  string page_token = 3;
+}
+
+// Response for listing notes for a tag (AIP-132)
+message ListNotesForTagResponse {
+  // List of notes with this tag
+  repeated Note notes = 1;
+
+  // Token for next page (empty if no more pages)
+  string next_page_token = 2;
+
+  // Total number of notes with this tag
+  optional int32 total_size = 3;
+}
+
+// Request to find tags by name pattern (AIP-136 custom method)
+message FindTagsRequest {
+  // Name pattern to search for (LIKE query, required)
+  // Use % for wildcards (e.g., "project%" matches "project", "projects", etc.)
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1,
+    max_len: 255
+  }];
+
+  // Maximum number of tags to return (default: 50, max: 100)
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 0,
+    lte: 100
+  }];
+
+  // Page token from previous response
+  string page_token = 3;
+}
+
+// Response for finding tags (AIP-136)
+message FindTagsResponse {
+  // Matching tags
+  repeated Tag tags = 1;
+
+  // Token for next page (empty if no more pages)
+  string next_page_token = 2;
+
+  // Total number of matching tags
+  optional int32 total_size = 3;
+}

--- a/store/mind/sql/tags.sql
+++ b/store/mind/sql/tags.sql
@@ -81,3 +81,25 @@ SELECT COUNT(*) FROM tags
 JOIN note_tags ON tags.id = note_tags.tag_id
 WHERE note_tags.note_id = :note_id;
 
+-- name: ListNotesForTagPaginated :many
+SELECT notes.* FROM notes
+JOIN note_tags ON notes.id = note_tags.note_id
+WHERE note_tags.tag_id = :tag_id
+ORDER BY notes.id
+LIMIT :limit OFFSET :offset;
+
+-- name: CountNotesForTag :one
+SELECT COUNT(*) FROM notes
+JOIN note_tags ON notes.id = note_tags.note_id
+WHERE note_tags.tag_id = :tag_id;
+
+-- name: FindTagsPaginated :many
+SELECT * FROM tags
+WHERE name LIKE :pattern
+ORDER BY id
+LIMIT :limit OFFSET :offset;
+
+-- name: CountFindTags :one
+SELECT COUNT(*) FROM tags
+WHERE name LIKE :pattern;
+


### PR DESCRIPTION
## Summary

Implements the missing Tags V3 API endpoints for core PKM tag navigation functionality.

- **ListNotesForTag** - Paginated list of notes for a specific tag (`GET /tags/{tag_id}/notes`)
- **FindTags** - Search tags by name pattern using LIKE query (`POST /tags:find`)

## Changes

- `store/mind/sql/tags.sql` - Added paginated queries and counts
- `proto/mind/v3/tags.proto` - Added RPC definitions and messages
- `internal/mind/tags/tags_services.go` - Added service methods
- `internal/mind/tags/tags_handlers.go` - Implemented handlers with standard pagination
- `internal/mind/tags/tags_converters.go` - Added Note converters (local copy to avoid import cycle)

## Notes

- Created local `StoreNoteToProto` converter in tags package to avoid import cycle (notes → tags → notes)
- Both endpoints follow the established pagination pattern (page_size, page_token, total_size on first page)

Closes #39